### PR TITLE
Create fields on client-side as well

### DIFF
--- a/timestampable.coffee
+++ b/timestampable.coffee
@@ -59,24 +59,21 @@ behaviour = (options = {}) ->
       addAfDefs def if af?
 
     @collection.attachSchema new SimpleSchema definition
+  
+  @collection.before.insert (userId = systemId, doc) ->
+    if createdAt
+      doc[createdAt] = new Date
+    if createdBy and not doc[createdBy]?
+      doc[createdBy] = userId
 
-  isLocalCollection = @collection._connection is null
+  @collection.before.update (userId = systemId, doc, fieldNames, modifier,
+    options) ->
 
-  if Meteor.isServer or isLocalCollection
-    @collection.before.insert (userId = systemId, doc) ->
-      if createdAt
-        doc[createdAt] = new Date
-      if createdBy and not doc[createdBy]?
-        doc[createdBy] = userId
+    $set = modifier.$set ?= {}
 
-    @collection.before.update (userId = systemId, doc, fieldNames, modifier,
-      options) ->
-
-      $set = modifier.$set ?= {}
-
-      if updatedAt
-        $set[updatedAt] = new Date
-      if updatedBy and not $set[updatedBy]?
-        $set[updatedBy] = userId
+    if updatedAt
+      $set[updatedAt] = new Date
+    if updatedBy and not $set[updatedBy]?
+      $set[updatedBy] = userId
 
 CollectionBehaviours.define 'timestampable', behaviour


### PR DESCRIPTION
I guess createdAt & createdBy weren't created client-side to avoid data manipulation, but hooks are ran client and server side, like methods, so datas can't be corrupted (if so, server side will insert correct datas and sync all clients with them).

Not having these two fields client-side created some glitches and I had to test if they were present. For example, I couldn't display a comment's author username before server sync. More code for me, weaker experience for users.

That said, I may have misunderstood why you did this though! :)

(This comment was automatically copied from @nicooprat)
